### PR TITLE
feat: add GitHub release actions

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,114 @@
+name: Build App
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches: 
+      - '*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  APP_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  refs:
+    name: Prepare CI Vars
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.refs.outputs.sha_short }}
+      short_ref: ${{ steps.refs.outputs.short_ref }}
+      version: ${{ steps.refs.outputs.version }}
+      new_release: ${{ steps.refs.outputs.new_release }}
+    steps:
+      - name: Source checkout
+        uses: actions/checkout@v2
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          dry_run: true
+          semantic_version: 18
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set outputs
+        id: refs
+        run: |
+          export BRANCH=${GITHUB_REF#refs/*/}
+          echo "branch: ${BRANCH}"
+          export BRANCHTRANSLATED=$(echo ${BRANCH} | tr '/' '_')
+          echo "short_ref: ${BRANCHTRANSLATED}"
+          export VERSION=""
+          if ${{ steps.semantic.outputs.new_release_published == 'true' }}; then
+            export VERSION=${{ steps.semantic.outputs.new_release_version }}
+          else
+            export VERSION=${BRANCHTRANSLATED}_$(git rev-parse --short=12 HEAD)
+          fi
+          echo "new_release: ${{ steps.semantic.outputs.new_release_published }}"
+          echo "version: ${VERSION}"
+          echo "::set-output name=new_release::${{ steps.semantic.outputs.new_release_published }}"
+          echo "::set-output name=short_ref::${BRANCHTRANSLATED}"
+          echo "::set-output name=sha_short::SHA-$(git rev-parse --short=12 HEAD)"
+          echo "::set-output name=version::${VERSION}"
+  build:
+    name: Build
+    needs: refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Source checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get -y install libc6-i386 make
+      - run: ls -la
+      - name: Run make
+        run: make APP_VERSION=${{ needs.refs.outputs.version }} APP_NAME=${{ env.APP_NAME }} build
+      - name: Save build assets
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.APP_NAME }}_${{ needs.refs.outputs.version }}
+          path: |
+            output/${{ needs.refs.outputs.version }}/${{ env.APP_NAME }}_UA_${{ needs.refs.outputs.version }}.bin
+            output/${{ needs.refs.outputs.version }}/${{ env.APP_NAME }}_${{ needs.refs.outputs.version }}.rbl
+          if-no-files-found: error         
+
+  release:
+    name: Semantic Release Images and Artifacts
+    runs-on: ubuntu-latest
+    needs: [ refs, build ]
+    if: ${{ needs.refs.outputs.new_release == 'true' && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Source checkout
+        uses: actions/checkout@v2
+      - name: Fetch build assets
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.APP_NAME }}_${{ needs.refs.outputs.version }}
+          path: output/${{ needs.refs.outputs.version }}
+      - name: Run Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          dry_run: false
+          semantic_version: 18
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Echo Semantic Release Versions
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.semantic.outputs.new_release_version }}
+          echo ${{ steps.semantic.outputs.new_release_major_version }}
+          echo ${{ steps.semantic.outputs.new_release_minor_version }}
+          echo ${{ steps.semantic.outputs.new_release_patch_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output/**
 **/*.o
+/custom.mk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sdk"]
+	path = sdk
+	url = https://github.com/openshwprojects/OpenBK7231T.git

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,80 @@
+branches: 
+  - 'main'
+preset: "angular"
+tagFormat: "${version}"
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"
+  - "@semantic-release/github"
+verifyConditions:
+  - '@semantic-release/git'
+  - "@semantic-release/github"
+analyzeCommits:
+  - path: "@semantic-release/commit-analyzer"
+    releaseRules:
+    - type: "feat"
+      release: "patch"
+    - type: "hotfix"
+      release: "patch"
+    - type: "fix"
+      release: "patch"
+    - type: "patch"
+      release: "patch"
+    - type: "minor"
+      release: "minor"
+    - type: "breaking"
+      release: "major"
+    - type: "chore"
+      release: "patch"
+generateNotes:
+  - path: "@semantic-release/release-notes-generator"
+    writerOpts:
+      groupBy: "type"
+      commitGroupsSort:
+        - "hotfix"
+        - "feat"
+        - "perf"
+        - "fix"
+      commitsSort: "header"
+    types:
+    - type: "feat"
+    - section: "Features"
+    # Tracked bug fix with a hotfix branch
+    - type: "hotfix"
+    - section: "Bug Fixes"
+    # Uninmportent fix (CI testing, etc)
+    - type: "fix"
+    - section: "Bug Fixes"
+    - type: "chore"
+    - section: "Bug Fixes"
+    - type: "docs"
+    - hidden: true
+    - type: "doc"
+    - hidden: true
+    - type: "style"
+    - hidden: true
+    - type: "refactor"
+    - hidden: true
+    - type: "perf"
+    - hidden: true
+    - type: "test"
+    - hidden: true
+    presetConfig: true
+prepare:
+  - path: "@semantic-release/git"
+  - path: "@semantic-release/changelog"
+    changelogFile: "CHANGELOG.md"
+publish:
+  - path: "@semantic-release/github"
+    addReleases: "bottom"
+    assets:
+      - path: "output/**/*_UA_*.bin"
+      - path: "output/**/*.rbl"
+
+success:
+  - "@semantic-release/github"
+
+fail:
+  - "@semantic-release/github"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+# HACK - if COMPILE_PREX defined then we are being called running from original build_app.sh script in standard SDK
+# Required to not break old build_app.sh script lines 74-77
+ifdef COMPILE_PREX
+all:
+	@echo Calling original build_app.sh script
+	cd $(PWD)/../../platforms/$(TARGET_PLATFORM)/toolchain/$(TUYA_APPS_BUILD_PATH) && sh $(TUYA_APPS_BUILD_CMD) $(APP_NAME) $(APP_VERSION) $(TARGET_PLATFORM)
+else
+
+######## Continue with custom simplied Makefile ########
+
+# Use current folder name as app name
+APP_NAME ?= $(shell basename $(CURDIR))
+# Use current timestamp as version number
+TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
+APP_VERSION ?= dev_$(TIMESTAMP)
+
+TARGET_PLATFORM ?= bk7231t
+APPS_BUILD_PATH ?= ../bk7231t_os
+APPS_BUILD_CMD ?= build.sh
+
+# Default target is to run build
+all: build
+
+# Full target will clean then build all
+.PHONY: full
+full: clean build
+
+# Update/init git submodules
+.PHONY: submodules
+submodules:
+	git submodule update --init --recursive
+
+# Create symlink for App into SDK folder structure
+sdk/apps/$(APP_NAME):
+	@echo Create symlink for $(APP_NAME) into sdk/apps folder
+	ln -s "$(shell pwd)/" "sdk/apps/$(APP_NAME)"
+
+# Build main binary
+.PHONY: build
+build: submodules sdk/apps/$(APP_NAME)
+	cd sdk/platforms/$(TARGET_PLATFORM)/toolchain/$(APPS_BUILD_PATH) && sh $(APPS_BUILD_CMD) $(APP_NAME) $(APP_VERSION) $(TARGET_PLATFORM)
+
+# clean .o files
+.PHONY: clean
+clean: 
+	$(MAKE) -C sdk/platforms/$(TARGET_PLATFORM)/toolchain/$(APPS_BUILD_PATH) APP_BIN_NAME=$(APP_NAME) USER_SW_VER=$(APP_VERSION) clean
+	rm -rf output/*
+
+# Add custom Makefile if required
+-include custom.mk
+
+endif


### PR DESCRIPTION
Use GitHub actions to automated build and release versions. Uses [Conventional Commits](https://www.conventionalcommits.org/) to automatically increment release versions and generate change logs.